### PR TITLE
fix: Fixing Icon Button color secondary hover color for e4e theme

### DIFF
--- a/src/styles/themeEncourageE4E/components.ts
+++ b/src/styles/themeEncourageE4E/components.ts
@@ -794,7 +794,7 @@ export const components: ThemeOptions['components'] = {
       },
       colorSecondary: {
         '&:hover': {
-          backgroundColor: palette.branding.sapphire[100],
+          backgroundColor: palette.branding.sapphire[30],
         },
         backgroundColor: palette.branding.sapphire[10],
         color: palette.branding.sapphire[100],


### PR DESCRIPTION
On the recent update of the E4E theme colors, one change was missing, in which the color on hover for the MuiIconButton for the colorSecondary variant should go from sapphire[100] to sapphire[30]