### PR TITLE
docs: Add DLS maintenance guidance

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,10 +15,13 @@ To run the DLS locally:
 
 When you're ready to pilot your changes to this library in your local project:
 
-1. Run the `npm run pack` command. When it finishes running, it will generate a
-   `.tgz` file in the `/dist` folder with the following name format
+1. Run `npm run build` to generate a fresh package build in the `dist` folder.
+
+2. Run `npm pack ./dist --pack-destination ./dist`. When it finishes running,
+   it will generate a `.tgz` file in the `/dist` folder with the following name format
    `encoura-dls-<version-number>.tgz`;
-2. Access the `package.json` file of your local project in which the
+
+3. Access the `package.json` file of your local project in which the
    `@encoura/dls` package will be tested, and make the following edit:
 
    ```json
@@ -31,15 +34,16 @@ When you're ready to pilot your changes to this library in your local project:
    }
    ```
 
-3. Run `npm update @encoura/dls` to refresh your project's `node_modules` folder.
+4. Run `npm update @encoura/dls` to refresh your project's `node_modules` folder.
 
-4. You can now run your project with the local changes made to this library!
+5. You can now run your project with the local changes made to this library!
 
-5. If you want to make any further edits to this library, simply run
-   `npm run pack` to package up the changes, and then `npm update @encoura/dls`
-   in your local project to pull them in.
+6. If you want to make any further edits to this library, simply run
+   `npm run build` and `npm pack ./dist --pack-destination ./dist` to package
+   up the changes, and then `npm update @encoura/dls` in your local project to
+   pull them in.
 
-6. When you're done piloting the changes, simply revert your project's
+7. When you're done piloting the changes, simply revert your project's
    `package.json` file to pull this library from NPM, and run
    `npm update @encoura/dls` to refresh your project's `node_modules` folder.
 

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -1,0 +1,51 @@
+# Maintaining the DLS
+
+This document captures maintenance guidance for keeping the DLS generic,
+portable, and useful across downstream React applications.
+
+## Package Scope
+
+The DLS should stay thin. A component is a good fit for this package when it is:
+
+- Generic enough to be reused across multiple products
+- Driven by props, composition, slots, and theme values instead of application
+  assumptions
+- Decoupled from business logic, network calls, routing, and product-specific
+  data models
+- Flexible enough for downstream teams to change the UX without forking the
+  component
+
+A component is a candidate for deprecation, replacement, or migration out of
+the DLS when it is highly design-constrained, models a one-off product flow, or
+cannot be adapted without changing its internals.
+
+## MUI Reference Stories
+
+The `_muiCore` and `_muiX` folders under `src/components` are intentionally
+Storybook-only reference stories. They preview how upstream MUI Core and MUI X
+components render under each DLS theme, using the Storybook theme picker.
+
+These stories should not be exported from `src/components/index.ts` or treated
+as public DLS components. Their value is documentation and visual regression
+coverage: Chromatic snapshots make MUI upgrades easier to evaluate because
+theme-level rendering changes are visible before they reach downstream apps.
+
+## Story Coverage
+
+New and changed components should include Storybook stories for important
+states, variants, and edge cases. Prefer examples that demonstrate real
+component behavior without relying on private product context.
+
+Add Storybook `play` functions when behavior can be exercised through the
+browser, such as opening menus, selecting rows, confirming dialogs, or validating
+empty states. Over time, these interactions should help Storybook coverage
+reflect the component behaviors that matter most.
+
+## Chart Components
+
+The current chart components are custom wrappers around Recharts. They should be
+maintained conservatively and treated as deprecation candidates when their fixed
+UX or styling makes them difficult to reuse across products.
+
+For future chart work, evaluate whether MUI X Charts can provide a more flexible
+foundation before adding new custom Recharts-based components to the DLS.

--- a/docs/STANDARDS.md
+++ b/docs/STANDARDS.md
@@ -33,7 +33,12 @@ company-wide standards. This approach allows us to:
 | **Maps**              | <a href="https://www.mapbox.com/" target="_blank">Mapbox</a> (DLS provides custom Map components via <a href="https://visgl.github.io/react-map-gl/" target="_blank">react-map-gl</a>)                                                                                                              | None                                                                       |
 | **Forms**             | <a href="https://react-hook-form.com/" target="_blank">React Hook Form</a>                                                                                                                                                                                                                          | None                                                                       |
 | **Component Testing** | <a href="https://www.chromatic.com/" target="_blank">Chromatic</a> & <a href="https://storybook.js.org/" target="_blank">Storybook</a>                                                                                                                                                              | None                                                                       |
-| **Unit Testing**      | <a href="https://jestjs.io/" target="_blank">Jest</a>                                                                                                                                                                                                                                               | <a href="https://vitest.dev/" target="_blank">Vitest</a>                   |
+| **Unit Testing**      | <a href="https://vitest.dev/" target="_blank">Vitest</a>                                                                                                                                                                                                                                            | None                                                                       |
+
+The existing custom chart components are candidates for deprecation if they
+remain too design-constrained to adapt cleanly across products. For future
+chart work, evaluate whether lower-level MUI X Charts primitives offer a more
+flexible long-term foundation than adding more custom Recharts wrappers here.
 
 ## Standard Adoption Process
 

--- a/src/_docs/7.MAINTAINING.mdx
+++ b/src/_docs/7.MAINTAINING.mdx
@@ -1,0 +1,7 @@
+import { Markdown, Meta } from '@storybook/addon-docs/blocks';
+
+import MAINTAINING from '~/../docs/MAINTAINING.md?raw';
+
+<Meta title="DLS/Maintaining" />
+
+<Markdown>{MAINTAINING}</Markdown>


### PR DESCRIPTION
## Summary
- correct local package iteration docs to use `npm pack` against the built `dist` package
- add OSS-safe DLS maintenance guidance for package scope, Storybook-only MUI reference stories, story `play` functions, and chart component deprecation criteria
- update the standards doc now that Vitest is the current unit test runner

## Validation
- `npm ci`
- `npm test`
- `npm run build-storybook`
- `npm pack ./dist --pack-destination ./dist --dry-run`
- `git diff --check`