### PR TITLE
fix: Shim Jest lint version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,4 +44,11 @@ module.exports = {
       ],
     ],
   },
+  settings: {
+    jest: {
+      // Jest removed; version hint keeps eslint-plugin-jest inherited from
+      // @encoura/eslint-config from crashing. Remove once shared config drops Jest.
+      version: 30,
+    },
+  },
 };


### PR DESCRIPTION
## Summary

- add an explicit Jest version hint for inherited `eslint-plugin-jest` rules
- document that the shim can be removed once `@encoura/eslint-config` drops Jest assumptions
- keep the inherited Jest rule behavior active while avoiding the version autodetect crash on fresh Vitest installs

## Validation

- `npm ci`
- `npx eslint src/helpers/cssRadius/index.test.ts --ext .ts,.tsx --quiet`
- `npx eslint . --ext .ts,.tsx --quiet`
- `npx eslint --print-config src/helpers/cssRadius/index.test.ts | rg -n '"jest"|"version": 30|jest/no-deprecated-functions' -C 2`
- `npm run test:lint:js`
- `npm run test:lint:ts`
- `npm run test:prettier`
- `git diff --check`

## Notes

This unblocks Dependabot branches whose regenerated lockfiles no longer include the accidental `jest` package resolution. Follow-up upstream ESLint modernization is tracked in AP-6277.
