### PR TITLE
docs: Add repository agent guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+
+_Provide public context and explain the solution._
+
+## Consumer / Release Impact
+
+_Describe affected exports, components, helpers, themes, docs, or package
+consumers. Note "No runtime/package impact" for docs, tests, or tooling-only
+changes._
+
+## QA Steps
+
+_List commands run, Storybook checks, package tarball validation, or other
+verification. If validation is not applicable, say why._
+
+## Screenshots
+
+_Provide pictures or recordings for UI work, if available._
+
+## DLS Contributor Notes
+
+- [ ] Keep the PR title/body and all commits public-safe; do not include
+      non-public references, private links, or private organization/project
+      context
+- [ ] Verify each commit uses the correct conventional-commit token because DLS
+      does not squash commits before semantic-release analyzes them; see
+      [`docs/CONTRIBUTING.md#committing-code`](../docs/CONTRIBUTING.md#committing-code)
+- [ ] Add or update unit tests for changed helpers, hooks, and non-trivial
+      component logic
+- [ ] Add or update Storybook stories/docs for shared UI changes and new visual
+      states
+- [ ] Verify public exports from `src/index.ts` and grouped barrels when adding
+      consumer-facing APIs
+- [ ] Confirm component, theme, and docs changes stay generic enough for DLS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,168 @@
+# AGENTS.md
+
+## Scope
+
+These instructions apply to the whole repo. Prefer existing patterns, keep
+changes focused, and treat package compatibility and public OSS readability as
+part of the work.
+
+## Before Editing
+
+- Use the Node version in `.nvmrc`; run `nvm use` before `npm` commands.
+- Inspect nearby implementation, tests, stories, docs, exports, and known
+  public API usage before changing an area.
+- Use `rg` to find similar components, helpers, theme tokens, constants, export
+  paths, and public APIs.
+- If ownership is unclear, keep the change local and call out the uncertainty
+  instead of turning one use case into a design-system pattern.
+
+## What DLS Is
+
+- DLS is the public package `@encoura/dls`.
+- DLS owns generic, theme-driven design-system foundations for Encoura React
+  applications: base components, themes, helpers, hooks, constants, and public
+  types that can be reused without private product context.
+- DLS should stay decoupled from product-specific business logic, network calls,
+  routing, feature flags, and private data models.
+- A library change reaches users only after the package is released and a
+  consuming project upgrades to that release and deploys.
+
+## OSS Boundary
+
+- Keep commits, branch names, PR titles, PR bodies, changelog-facing text, and
+  public docs free of non-public references, organization-specific details,
+  private project names, and private incident context.
+- If additional context exists outside the public repo, keep it outside the
+  public repo. Use friendly, public explanations such as "requested by
+  maintainers" or "follow-up from maintainership discussion" when context is
+  needed.
+- Do not commit secrets, local config values, service tokens, licensed assets,
+  screenshots containing private data, or other non-public artifacts.
+
+## Commands
+
+- Install: `npm install`
+- Start Storybook: `npm start`
+- Build package: `npm run build`
+- Build Storybook: `npm run build-storybook`
+- Watch package build for local package testing: `npm run watch`
+- Broad validation: `npm test`
+- Markdown lint: `npm run test:lint:md`
+- Prettier check: `npm run test:prettier`
+- Typecheck: `npm run test:types`
+- Unit tests: `npm run test:unit`
+- Storybook browser tests: `npm run test:storybook`
+
+Prefer focused validation first, then broaden when shared behavior, public API,
+theme behavior, or release output changes. `npm test` runs the full script set,
+including build and Storybook browser tests, so expect it to take longer than a
+targeted command.
+
+## Repo Map
+
+- `src/index.ts`: top-level public exports.
+- `src/components`: exported DLS components and Storybook-only MUI reference
+  stories under `_muiCore` and `_muiX`.
+- `src/constants`: public constants, including component names, slot names,
+  chart colors, and sort directions.
+- `src/context`, `src/helpers`, `src/hooks`, `src/styles`, `src/types`: shared
+  context, utilities, hooks, theme exports, and public types.
+- `src/_foundations`: Storybook foundations for colors, palette, typography,
+  spacing, shape, shadows, and theme demos.
+- `src/_docs`: Storybook docs pages that mirror the root README, changelog, and
+  docs folder.
+- `docs`: contributor, guide, standards, icon, and maintainer documentation.
+- `.storybook`: Storybook/Vite config, preview providers, and Chromatic helpers.
+- `public`: static assets copied into Storybook and package output.
+- `dist`: generated package output. Do not hand-edit or commit local builds.
+
+## Package Boundaries
+
+- Use DLS for reusable, product-agnostic UI foundations driven by props,
+  composition, slots, and theme values.
+- Use higher-level packages or consuming projects for business logic, network
+  calls, routing, feature flags, product-specific UX, product data models, or
+  one-off workflows.
+- Do not add custom chart wrappers back to DLS. Theme compatibility examples or
+  reference stories are fine, but product chart abstractions belong in a layer
+  with the right ownership boundary.
+- Keep MUI reference stories documentation-only. `_muiCore` and `_muiX` stories
+  should not be exported from `src/components/index.ts` or treated as public
+  DLS components.
+- Preserve package consumers unless there is an explicit migration plan. For
+  public API changes, search available usage and document migration notes.
+
+## Public API
+
+- Public exports flow through `src/index.ts` and grouped barrels for
+  `components`, `constants`, `context`, `helpers`, `hooks`, `styles`, and
+  `types`.
+- If a new component/helper/type is intended for consumers, export it from the
+  nearest barrel and confirm the package build emits the desired path.
+- Avoid exporting implementation-only helpers, story fixtures, mocks,
+  Storybook-only reference components, or test utilities.
+- Keep module augmentation files import-alias-free so consuming `tsconfig`
+  includes can consume them from `node_modules`.
+
+## Code And Styling
+
+- Prefer TypeScript and explicit nullable handling.
+- Use `~/*` for imports from `src`; keep relative imports inside the same
+  component/helper folder. Storybook and Vitest also define `src` as an alias.
+- Match nearby component folders: usually `index.tsx`, optional `styles.ts`,
+  `index.stories.tsx`, mocks, and focused tests where logic exists.
+- Put reusable component styling in sibling `styles.ts` files with the DLS
+  styled helper or MUI styled patterns already used nearby.
+- Prefer DLS and MUI theme values over hard-coded pixels, colors, z-indexes,
+  shadows, and typography. Use theme spacing, typography, palette, shape, and
+  component slot/class conventions where possible.
+- Use deep lodash imports instead of named imports from `lodash`; lint enforces
+  this for bundle-size reasons.
+- Shared UI should account for applicable loading, empty, error, disabled,
+  responsive, localization, and theme-variant states.
+- DLS components should stay flexible through props, slots, and composition
+  rather than hidden product assumptions.
+
+## Stories, Tests, And Visuals
+
+- Add/update unit tests for changed helpers, hooks, and non-trivial component
+  logic.
+- Add/update Storybook stories for shared UI states, variants, themes, and edge
+  cases. Prefer examples that demonstrate generic behavior without private
+  product context.
+- Add Storybook `play` functions when behavior can be exercised in the browser,
+  such as opening menus, selecting rows, confirming dialogs, or validating empty
+  states.
+- For Chromatic-sensitive stories, use stable dimensions/data, fixed dates,
+  disabled animation where appropriate, and the helpers in
+  `.storybook/chromatic.ts`.
+- Storybook browser tests require Playwright Chromium; `pretest:storybook`
+  installs it locally.
+- Update snapshots or visual baselines only when the rendered change is
+  intentional.
+
+## Release And PRs
+
+- DLS does not squash commits before release analysis. Each commit that lands on
+  `main` must use the correct conventional-commit token because semantic-release
+  reads the commits directly.
+- Keep commit and PR text public-safe. Do not include non-public tracking or
+  project context.
+- Use release-triggering commit prefixes only when the package should publish a
+  consumer-facing release. Docs/tests/tooling-only changes should use
+  non-runtime prefixes such as `docs:`, `test:`, `build:`, or `chore:`.
+- Keep the release-token rules in
+  [`docs/CONTRIBUTING.md#committing-code`](./docs/CONTRIBUTING.md#committing-code)
+  as the source of truth.
+- Use `.github/pull_request_template.md`; call out consumer impact, validation,
+  screenshots for UI work, skipped checks, and any needed package testing or
+  release plan.
+- Chromatic may require GitHub environment approval before the check runs.
+
+## Avoid
+
+- Do not commit `node_modules/`, `dist/`, `storybook-static/`, `coverage/`,
+  local `.env`, `.npmrc`, logs, tarballs, screenshots, or videos.
+- Do not hand-edit generated package output in `dist`.
+- Do not change release workflows, semantic-release config, dependency
+  versions, or package metadata unless the task requires it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,23 @@ part of the work.
 - If ownership is unclear, keep the change local and call out the uncertainty
   instead of turning one use case into a design-system pattern.
 
+## Source Of Truth Docs
+
+Use these repo-local docs as the source of truth when a task needs deeper
+guidance:
+
+- [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md): local iteration, package
+  testing, npm scripts, and commit-token rules.
+- [`docs/GUIDE.md`](./docs/GUIDE.md): DLS component design principles,
+  including business-logic decoupling, technology assumptions, MUI usage,
+  theming, and reusable styling patterns.
+- [`docs/STANDARDS.md`](./docs/STANDARDS.md): current front-end technology
+  standards and how those standards evolve.
+- [`docs/ICONS.md`](./docs/ICONS.md): preferred icon sources and custom
+  `SvgIcon` guidance.
+- [`docs/MAINTAINING.md`](./docs/MAINTAINING.md): package scope, MUI reference
+  stories, story coverage expectations, and chart-component boundaries.
+
 ## What DLS Is
 
 - DLS is the public package `@encoura/dls`.
@@ -83,9 +100,10 @@ targeted command.
 - Use higher-level packages or consuming projects for business logic, network
   calls, routing, feature flags, product-specific UX, product data models, or
   one-off workflows.
-- Do not add custom chart wrappers back to DLS. Theme compatibility examples or
-  reference stories are fine, but product chart abstractions belong in a layer
-  with the right ownership boundary.
+- Defer to [`docs/MAINTAINING.md`](./docs/MAINTAINING.md) and
+  [`docs/STANDARDS.md`](./docs/STANDARDS.md) before changing chart guidance.
+  Theme compatibility examples or reference stories are fine, but product chart
+  abstractions belong outside DLS.
 - Keep MUI reference stories documentation-only. `_muiCore` and `_muiX` stories
   should not be exported from `src/components/index.ts` or treated as public
   DLS components.
@@ -116,6 +134,7 @@ targeted command.
 - Prefer DLS and MUI theme values over hard-coded pixels, colors, z-indexes,
   shadows, and typography. Use theme spacing, typography, palette, shape, and
   component slot/class conventions where possible.
+- Follow [`docs/ICONS.md`](./docs/ICONS.md) when adding or changing icons.
 - Use deep lodash imports instead of named imports from `lodash`; lint enforces
   this for bundle-size reasons.
 - Shared UI should account for applicable loading, empty, error, disabled,


### PR DESCRIPTION
## Summary

Adds a root `AGENTS.md` so coding agents have repo-local guidance before making DLS changes.

Also adds a lightweight PR template that keeps public PRs free of non-public context and reminds contributors that each DLS commit, not the squashed PR title, drives semantic-release.

The agent guidance now points to repo-local source-of-truth docs for contribution flow, design principles, current standards, icon guidance, and maintenance boundaries.

## Consumer / Release Impact

No runtime/package impact. Docs-only change.

Both commits use `docs:` so this should not publish a consumer-facing DLS release.

## QA Steps

- `npm ci`
- `npm run test:lint:md`
- `npx prettier AGENTS.md .github/pull_request_template.md --check`
- `npx commitlint --from origin/main --to HEAD`
- `git diff --check`
- targeted text scan for non-public tooling/context terms in `AGENTS.md` and `.github/pull_request_template.md`

## Screenshots

Not applicable; documentation-only change.

## DLS Contributor Notes

- [x] Keep the PR title/body and all commits public-safe; do not include non-public references, private links, or private organization/project context
- [x] Verify each commit uses the correct conventional-commit token because DLS does not squash commits before semantic-release analyzes them; see [`docs/CONTRIBUTING.md#committing-code`](../docs/CONTRIBUTING.md#committing-code)
- [x] Add or update unit tests for changed helpers, hooks, and non-trivial component logic
- [x] Add or update Storybook stories/docs for shared UI changes and new visual states
- [x] Verify public exports from `src/index.ts` and grouped barrels when adding consumer-facing APIs
- [x] Confirm component, theme, and docs changes stay generic enough for DLS
