### PR TITLE
docs: Clarify map component maintenance

### DIFF
--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -41,6 +41,16 @@ browser, such as opening menus, selecting rows, confirming dialogs, or validatin
 empty states. Over time, these interactions should help Storybook coverage
 reflect the component behaviors that matter most.
 
+## Map Components
+
+DLS map components are intentionally supported here because they solve a
+generic, widely reused visualization need across product lines. Keep map changes
+focused on reusable props and behavior rather than product-specific data shapes.
+
+Map stories should remain available for local Storybook review, but Chromatic
+snapshots are disabled by design. They depend on Mapbox tile rendering, which is
+not stable enough for pixel-perfect visual regression checks.
+
 ## Chart Components
 
 DLS no longer exports custom chart components. MUI X Charts and Recharts are


### PR DESCRIPTION
## Summary

Adds a short maintenance note documenting that DLS map components are intentionally supported long-term because they cover a generic, widely reused visualization need across product lines.

Also clarifies why map stories remain reviewable in local Storybook while Chromatic snapshots stay disabled: Mapbox tile rendering is not stable enough for pixel-perfect visual regression checks.

## Consumer / Release Impact

No runtime/package impact. Documentation-only change.

## QA Steps

- npm install
- npm test

## Screenshots

Not applicable; docs-only change.

## DLS Contributor Notes

- [x] Keep the PR title/body and all commits public-safe; do not include non-public references, private links, or private organization/project context
- [x] Verify each commit uses the correct conventional-commit token because DLS does not squash commits before semantic-release analyzes them; see docs/CONTRIBUTING.md#committing-code
- [x] Add or update unit tests for changed helpers, hooks, and non-trivial component logic
- [x] Add or update Storybook stories/docs for shared UI changes and new visual states
- [x] Verify public exports from src/index.ts and grouped barrels when adding consumer-facing APIs
- [x] Confirm component, theme, and docs changes stay generic enough for DLS
