### PR TITLE
fix: [E4E-2714]: Name the loading spinner instead of its container

### DIFF
--- a/src/components/Loading/index.test.tsx
+++ b/src/components/Loading/index.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Encoura, LLC and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Loading } from '.';
+
+describe('Loading', () => {
+  // The unit project does not enable Vitest globals, so Testing Library's automatic cleanup never
+  // registers and rendered trees would otherwise accumulate across tests.
+  afterEach(cleanup);
+
+  it('gives the spinner an accessible name by default', () => {
+    render(<Loading />);
+
+    expect(screen.getByRole('progressbar', { name: 'Loading ...' })).toBeInTheDocument();
+  });
+
+  it('names the spinner from aria-label when provided', () => {
+    render(<Loading aria-label="Loading results" />);
+
+    expect(screen.getByRole('progressbar', { name: 'Loading results' })).toBeInTheDocument();
+  });
+
+  it('prefers title over aria-label so the announcement matches the visible text', () => {
+    render(<Loading aria-label="Loading results" title="Loading students" />);
+
+    expect(screen.getByRole('progressbar', { name: 'Loading students' })).toBeInTheDocument();
+    expect(screen.getByText('Loading students')).toBeInTheDocument();
+  });
+
+  it('lets circularProgressProps override the name', () => {
+    render(<Loading circularProgressProps={{ 'aria-label': 'Custom name' }} />);
+
+    expect(screen.getByRole('progressbar', { name: 'Custom name' })).toBeInTheDocument();
+  });
+
+  // The container is a roleless <div>, where ARIA prohibits an accessible name. Keeping the name off
+  // it is the point of the markup, so guard against it drifting back.
+  it('does not put an accessible name on the roleless container', () => {
+    render(<Loading />);
+
+    expect(screen.getByTestId('loading')).not.toHaveAttribute('aria-label');
+    expect(screen.getByTestId('loading')).not.toHaveAttribute('aria-labelledby');
+  });
+});

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -15,6 +15,10 @@ export interface LoadingProps {
   circularProgressProps?: CircularProgressProps;
   style?: CSSProperties;
   title?: string;
+  /**
+   * Accessible name announced for the spinner. Defaults to `Loading ...`, and `title` takes
+   * precedence when provided so the announcement matches the visible text.
+   */
   'aria-label'?: string;
 }
 
@@ -27,8 +31,8 @@ export const Loading: FC<LoadingProps> = ({
   title,
   'aria-label': ariaLabel = 'Loading ...',
 }: LoadingProps): ReactElement<LoadingProps> => (
-  <StyledContainer aria-label={title || ariaLabel} data-chromatic="ignore" data-testid="loading" style={style}>
-    <CircularProgress size={24} thickness={4.5} title={title} {...circularProgressProps} />
+  <StyledContainer data-chromatic="ignore" data-testid="loading" style={style}>
+    <CircularProgress aria-label={title || ariaLabel} size={24} thickness={4.5} title={title} {...circularProgressProps} />
 
     {title && <StyledTypography variant="overline">{title}</StyledTypography>}
   </StyledContainer>


### PR DESCRIPTION
## Summary

`Loading` set its accessible name on the outer container, a `div` with no role.
ARIA prohibits naming a generic element, so whether that name is exposed is
engine-specific — WebKit surfaces it, other engines are not required to.
Meanwhile the inner `CircularProgress`, which *does* expose
`role="progressbar"`, had no accessible name at all unless a `title` was passed.

axe reported both problems: `aria-prohibited-attr` on the container and
`aria-progressbar-name` on the spinner.

This moves the name onto the spinner. The same text is announced on every
engine, and screen readers additionally convey the busy state.
`circularProgressProps` is still spread last, so callers can override the name.

Worth stating explicitly, because it shaped the fix: the container label was
**not** dead — VoiceOver does read it today. So the name had to be *moved*
rather than removed. Simply deleting the prohibited attribute would have
silenced a working announcement.

## Consumer / Release Impact

- **Runtime, patch-level.** `fix:` token, so semantic-release will publish a
  patch on the current major.
- **No public API change.** `circularProgressProps`, `style`, `title` and
  `aria-label` keep their existing shapes and defaults (`aria-label` still
  defaults to `Loading ...`, and `title` still takes precedence).
- **No visual change.** Only which element carries `aria-label` changed; the
  optional `title` caption renders exactly as before.
- **DOM/accessibility-tree change.** The container no longer has `aria-label`;
  the spinner now does. Consumers asserting on the container's accessible name
  in tests would need to target the `progressbar` role instead — this is the
  intended correction, and querying by `role="progressbar"` works in both the
  old and new markup.

## QA Steps

- `npm run test:unit` — 8 files / 29 tests pass, including 5 new `Loading` cases
  covering name precedence between `title`, `aria-label` and
  `circularProgressProps`, plus a guard that the container keeps no accessible
  name.
- `npm run test:storybook` — 68 files / 378 tests pass.
- `npm run test:types` — clean.
- `npm run test:prettier`, ESLint on the changed files — clean.
- `npm run build` — clean; verified the emitted `dist/components/Loading` carries
  the fix.
- **Downstream check:** built the package locally and installed it into a
  consuming application that renders this component. Its type-check passes with
  no errors, every deep import path it uses still resolves, and the axe failures
  that motivated this change (`aria-progressbar-name` and
  `aria-prohibited-attr`) no longer reproduce with no workaround at the call
  site.

One gap to flag: the announcement was verified through the accessibility tree
and axe, not with VoiceOver on real hardware. A named `role="progressbar"` should
read at least as well as the current container label, but that is reasoning
rather than a measurement.

## Screenshots

Not applicable — no rendered change. The diff only moves an ARIA attribute
between elements, so Storybook and Chromatic output should be identical.

## DLS Contributor Notes

- [x] Keep the PR title/body and all commits public-safe; do not include
      non-public references, private links, or private organization/project
      context
- [x] Verify each commit uses the correct conventional-commit token because DLS
      does not squash commits before semantic-release analyzes them; see
      [`docs/CONTRIBUTING.md#committing-code`](../docs/CONTRIBUTING.md#committing-code)
- [x] Add or update unit tests for changed helpers, hooks, and non-trivial
      component logic
- [x] Add or update Storybook stories/docs for shared UI changes and new visual
      states — existing `Loading` stories already cover every state; this change
      adds no new visual state, so coverage is unchanged
- [x] Verify public exports from `src/index.ts` and grouped barrels when adding
      consumer-facing APIs — no export changes
- [x] Confirm component, theme, and docs changes stay generic enough for DLS
